### PR TITLE
Add React frontend skeleton and expand tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+frontend/node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# data-investigation-platform
+# Data Investigation Platform
+
+This repository contains a lightweight prototype of a Data Investigation Platform inspired by the detailed design.
+
+## Setup
+
+Install dependencies using `poetry` and run the Flask application:
+
+```bash
+poetry install
+FLASK_APP=app.main flask run --reload
+```
+
+To start the Airflow scheduler and webserver (after initialization):
+
+```bash
+poetry run airflow db init
+poetry run airflow users create \
+    --username admin --firstname Admin --lastname User \
+    --role Admin --email admin@example.com --password admin
+poetry run airflow scheduler &
+poetry run airflow webserver -p 8080 &
+```
+
+The sample DAG in `dags/investigation_dag.py` demonstrates automated
+investigation tasks.
+
+### Frontend Development
+
+A minimal React application lives in `frontend/`. Install Node dependencies and start the development server with:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The dev server proxies API requests to the Flask backend.
+
+
+### Distributed Processing
+
+This prototype includes simple wrappers for executing SQL on Hive via
+Spark and consuming streaming data with Flink. See `src/app/services/spark.py`
+and `src/app/services/flink.py` for details.
+
+### Security and Permissions
+
+The `permissions` service exposes a pluggable interface so you can
+provide your own authorization logic. By default a very small role
+matrix is included. Investigation data is stored encrypted using a
+Fernet key from the `cryptography` package. When results are returned
+to clients a watermark based on the requesting user's identifier is
+embedded for traceability.
+
+Blockchain can be integrated at the audit-log layer if stricter
+immutability is required, but the prototype does not implement it.
+
+Run tests with:
+
+```bash
+pytest
+```

--- a/dags/investigation_dag.py
+++ b/dags/investigation_dag.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+
+def start_investigation():
+    print("Starting automated investigation")
+
+
+def finish_investigation():
+    print("Investigation complete")
+
+
+default_args = {
+    "start_date": datetime(2024, 1, 1),
+    "catchup": False,
+}
+
+with DAG(
+    "investigation_dag",
+    schedule_interval="@daily",
+    default_args=default_args,
+    tags=["investigation"],
+) as dag:
+
+    start = PythonOperator(task_id="start", python_callable=start_investigation)
+    end = PythonOperator(task_id="finish", python_callable=finish_investigation)
+
+    start >> end

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "data-investigation-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.0",
+    "@babel/preset-react": "^7.22.0",
+    "babel-loader": "^9.1.2",
+    "webpack": "^5.92.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Investigation Platform</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+
+export default function App() {
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    fetch('/health')
+      .then((res) => res.json())
+      .then((data) => setStatus(data.status))
+      .catch(() => setStatus('offline'));
+  }, []);
+
+  return (
+    <div>
+      <h1>Data Investigation Platform</h1>
+      <p>API status: {status}</p>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'public'),
+    filename: 'bundle.js'
+  },
+  devServer: {
+    static: path.resolve(__dirname, 'public'),
+    proxy: {
+      '/': 'http://localhost:5000'
+    }
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  }
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "data-investigation-platform"
+version = "0.1.0"
+description = "Data Investigation Platform"
+authors = ["AutoBot <bot@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+flask = "^3.0"
+pydantic = "^1.10"
+typer = "^0.9.0"
+apache-airflow = "^2.9.0"
+pyspark = "^3.5.0"
+pyflink = "^1.17.0"
+cryptography = "^42.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "^7.4.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,3 @@
+"""Data Investigation Platform core package."""
+
+from .main import app

--- a/src/app/api/investigations.py
+++ b/src/app/api/investigations.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, request, jsonify, abort
+from typing import List
+from uuid import UUID
+
+from ..models import Investigation
+from ..services.store import InvestigationStore
+from ..services.auth import get_current_user, User
+from ..services.watermark import add_watermark
+
+investigations_bp = Blueprint('investigations', __name__)
+
+store = InvestigationStore()
+
+@investigations_bp.route('/investigations', methods=['POST'])
+def create_investigation():
+    user = get_current_user()
+    data = request.get_json(force=True)
+    inv = Investigation(**data)
+    inv = store.create(inv, user)
+    return jsonify(add_watermark(inv.dict(), user))
+
+@investigations_bp.route('/investigations/<uuid:inv_id>')
+def get_investigation(inv_id: UUID):
+    user = get_current_user()
+    inv = store.get(inv_id, user)
+    if not inv:
+        abort(404)
+    return jsonify(add_watermark(inv.dict(), user))
+
+@investigations_bp.route('/investigations')
+def list_investigations():
+    user = get_current_user()
+    invs = store.list(user)
+    return jsonify([add_watermark(inv.dict(), user) for inv in invs])
+

--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -1,0 +1,14 @@
+import typer
+from .main import app
+
+client = app.test_client()
+
+cli = typer.Typer()
+
+@cli.command()
+def health():
+    response = client.get("/health")
+    typer.echo(response.json())
+
+if __name__ == "__main__":
+    cli()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,10 @@
+from flask import Flask, jsonify
+from .api.investigations import investigations_bp
+
+app = Flask(__name__)
+
+app.register_blueprint(investigations_bp, url_prefix="/api/v1")
+
+@app.route("/health")
+def health_check():
+    return jsonify(status="ok")

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,0 +1,1 @@
+from .investigation import Investigation

--- a/src/app/models/investigation.py
+++ b/src/app/models/investigation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from uuid import UUID, uuid4
+from datetime import datetime
+
+class Investigation(BaseModel):
+    id: UUID = Field(default_factory=uuid4)
+    title: str
+    description: Optional[str] = None
+    created_by: UUID
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    status: str = "active"
+    tags: List[str] = []

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,0 +1,7 @@
+from .store import InvestigationStore
+from .auth import User, get_current_user
+from .spark import query_hive
+from .flink import process_stream
+from .permissions import register_permission_system, get_permission_system
+from .encryption import encrypt, decrypt
+from .watermark import add_watermark

--- a/src/app/services/auth.py
+++ b/src/app/services/auth.py
@@ -1,0 +1,21 @@
+from uuid import UUID, uuid4
+from flask import abort
+from typing import Optional
+from pydantic import BaseModel
+
+class User(BaseModel):
+    id: UUID
+    role: str
+
+# Dummy user store
+_users = {
+    uuid4(): User(id=uuid4(), role="Admin")
+}
+
+def get_current_user() -> User:
+    # In real scenario, decode token etc.
+    # Here we return a static admin user for simplicity
+    user = next(iter(_users.values()))
+    if not user:
+        abort(401)
+    return user

--- a/src/app/services/encryption.py
+++ b/src/app/services/encryption.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+from cryptography.fernet import Fernet
+
+_key = Fernet.generate_key()
+_cipher = Fernet(_key)
+
+
+def encrypt(data: bytes) -> bytes:
+    return _cipher.encrypt(data)
+
+
+def decrypt(data: bytes) -> bytes:
+    return _cipher.decrypt(data)

--- a/src/app/services/flink.py
+++ b/src/app/services/flink.py
@@ -1,0 +1,14 @@
+try:
+    from pyflink.datastream import StreamExecutionEnvironment
+except Exception:  # pragma: no cover - pyflink not installed in tests
+    StreamExecutionEnvironment = None
+
+
+def process_stream(topic: str) -> None:
+    """Consume a stream using Flink."""
+    if StreamExecutionEnvironment is None:
+        raise RuntimeError("pyflink is not available")
+    env = StreamExecutionEnvironment.get_execution_environment()
+    # Placeholder for actual source; in real use, configure Kafka or other source
+    print(f"Processing stream from {topic}")
+    env.execute("process_stream")

--- a/src/app/services/permissions.py
+++ b/src/app/services/permissions.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from typing import Protocol
+from .auth import User
+
+class PermissionSystem(Protocol):
+    def has_access(self, user: User, resource: str, action: str) -> bool:
+        ...
+
+default_roles = {
+    "Admin": {"*": ["create", "read", "update", "delete"]},
+    "Analyst": {"investigation": ["read"]},
+}
+
+class BasicPermissionSystem:
+    def has_access(self, user: User, resource: str, action: str) -> bool:
+        perms = default_roles.get(user.role, {})
+        allowed = perms.get(resource, []) + perms.get("*", [])
+        return action in allowed
+
+_permission_provider: PermissionSystem = BasicPermissionSystem()
+
+def register_permission_system(provider: PermissionSystem) -> None:
+    global _permission_provider
+    _permission_provider = provider
+
+
+def get_permission_system() -> PermissionSystem:
+    return _permission_provider

--- a/src/app/services/spark.py
+++ b/src/app/services/spark.py
@@ -1,0 +1,16 @@
+from typing import Iterable
+
+try:
+    from pyspark.sql import SparkSession
+except Exception:  # pragma: no cover - pyspark not installed in tests
+    SparkSession = None
+
+
+def query_hive(sql: str) -> Iterable[dict]:
+    """Execute a Hive query using Spark and yield rows as dictionaries."""
+    if SparkSession is None:
+        raise RuntimeError("pyspark is not available")
+    spark = SparkSession.builder.enableHiveSupport().getOrCreate()
+    df = spark.sql(sql)
+    for row in df.collect():
+        yield row.asDict()

--- a/src/app/services/store.py
+++ b/src/app/services/store.py
@@ -1,0 +1,29 @@
+from typing import Dict, List
+from uuid import UUID
+from .auth import User
+from ..models import Investigation
+from .permissions import get_permission_system
+from .encryption import encrypt, decrypt
+
+class InvestigationStore:
+    def __init__(self):
+        self._store: Dict[UUID, bytes] = {}
+
+    def create(self, inv: Investigation, user: User) -> Investigation:
+        if not get_permission_system().has_access(user, "investigation", "create"):
+            raise PermissionError("access denied")
+        self._store[inv.id] = encrypt(inv.json().encode())
+        return inv
+
+    def get(self, inv_id: UUID, user: User) -> Investigation | None:
+        if inv_id not in self._store:
+            return None
+        if not get_permission_system().has_access(user, "investigation", "read"):
+            raise PermissionError("access denied")
+        data = decrypt(self._store[inv_id])
+        return Investigation.parse_raw(data)
+
+    def list(self, user: User) -> List[Investigation]:
+        if not get_permission_system().has_access(user, "investigation", "read"):
+            raise PermissionError("access denied")
+        return [Investigation.parse_raw(decrypt(item)) for item in self._store.values()]

--- a/src/app/services/watermark.py
+++ b/src/app/services/watermark.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from hashlib import sha1
+from .auth import User
+
+
+def add_watermark(data: dict, user: User) -> dict:
+    mark = sha1(str(user.id).encode()).hexdigest()
+    data = dict(data)
+    data["_watermark"] = mark
+    return data

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,12 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from typer.testing import CliRunner
+from app.cli import cli
+
+
+def test_health_command():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['health'])
+    assert result.exit_code == 0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,12 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from app.main import app
+
+client = app.test_client()
+
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,12 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from app.models import Investigation
+from uuid import uuid4
+
+
+def test_model_defaults():
+    inv = Investigation(title='x', created_by=uuid4())
+    assert inv.status == 'active'
+    assert inv.id

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,29 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import uuid
+import pytest
+from app.models import Investigation
+from app.services.store import InvestigationStore
+from app.services.auth import User
+from app.services.permissions import register_permission_system
+from app.services.watermark import add_watermark
+
+class DenyAll:
+    def has_access(self, user, resource, action):
+        return False
+
+
+def test_permission_denied():
+    store = InvestigationStore()
+    user = User(id=uuid.uuid4(), role="Analyst")
+    register_permission_system(DenyAll())
+    with pytest.raises(PermissionError):
+        store.create(Investigation(title="t", created_by=user.id), user)
+
+
+def test_watermark_added():
+    user = User(id=uuid.uuid4(), role="Admin")
+    data = add_watermark({"foo": "bar"}, user)
+    assert "_watermark" in data

--- a/tests/test_spark_flink.py
+++ b/tests/test_spark_flink.py
@@ -1,0 +1,19 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
+from app.services.spark import query_hive, SparkSession
+from app.services.flink import process_stream, StreamExecutionEnvironment
+
+
+def test_spark_unavailable():
+    if SparkSession is None:
+        with pytest.raises(RuntimeError):
+            list(query_hive("SELECT 1"))
+
+
+def test_flink_unavailable():
+    if StreamExecutionEnvironment is None:
+        with pytest.raises(RuntimeError):
+            process_stream("topic")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,16 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import uuid
+from app.models import Investigation
+from app.services.store import InvestigationStore
+from app.services.auth import User
+
+
+def test_create_and_get():
+    store = InvestigationStore()
+    user = User(id=uuid.uuid4(), role='Admin')
+    inv = store.create(Investigation(title='t', created_by=user.id), user)
+    fetched = store.get(inv.id, user)
+    assert fetched.id == inv.id


### PR DESCRIPTION
## Summary
- introduce simple React frontend with webpack configuration
- document how to run the frontend in the README
- ignore frontend node modules in git
- add unit tests for the CLI, models and encrypted store

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845971150d883218421654d10d7b19c